### PR TITLE
Increased MQTTClient buffer size

### DIFF
--- a/src/EspSparsnasGateway.cpp
+++ b/src/EspSparsnasGateway.cpp
@@ -23,7 +23,7 @@
 #define _interruptNum 5 // = ESP8266 GPIO5
 
 WiFiClient wClient;
-MQTTClient mClient;
+MQTTClient mClient = MQTTClient(256);
 const char* mqtt_status_topic = "EspSparsnasGateway/valuesV2";
 const char* mqtt_debug_topic = "EspSparsnasGateway/debugV2";
 

--- a/src/RFM69functions.cpp
+++ b/src/RFM69functions.cpp
@@ -6,8 +6,7 @@
 #include <ArduinoJson.h>
 #include <RFM69registers.h>
 
-static WiFiClient wClient;
-static MQTTClient mClient;
+extern MQTTClient mClient;
 
 #define RF69_MODE_SLEEP 0      // XTAL OFF
 #define RF69_MODE_STANDBY 1    // XTAL ON
@@ -423,7 +422,7 @@ void  ICACHE_RAM_ATTR interruptHandler() {
       output += "Vcc: " + String(vcc) + "mV";
       Serial.println(output);
 
-      const size_t capacity = JSON_OBJECT_SIZE(8);
+      const size_t capacity = JSON_OBJECT_SIZE(9);
       DynamicJsonDocument status(capacity);
       if (err=="CRC ERR") {
         Serial.println(err);

--- a/src/mqttpub.cpp
+++ b/src/mqttpub.cpp
@@ -9,5 +9,5 @@ bool mqttpub(String topic, String subject, String mess, int size) {
   String mqttMess;
   status[subject] = mess;
   serializeJson(status, mqttMess);
-  mClient.publish(topic, mqttMess);
+  return mClient.publish(topic, mqttMess);
 }


### PR DESCRIPTION
Increased MQTTClient buffer size from (default) 128 to 256 to be able to fit larger JSON messages.
Fix compilation warning.
extern MQTTClient.