### PR TITLE
Don't use strings for integer types in JSON message

### DIFF
--- a/src/RFM69functions.cpp
+++ b/src/RFM69functions.cpp
@@ -437,13 +437,13 @@ void  ICACHE_RAM_ATTR interruptHandler() {
       }
 
       status["seq"] = seq;
-      status["timestamp"] = String(now);
+      status["timestamp"] = now;
       status["watt"] = float(watt);
       status["total"] = float(pulse) / float(PULSES_PER_KWH);
       status["battery"] = battery;
-      status["rssi"] = String(srssi);
-      status["power"] = String(power);
-      status["pulse"] = String(pulse);
+      status["rssi"] = srssi;
+      status["power"] = power;
+      status["pulse"] = pulse;
 
       String mqttMess;
       serializeJson(status, mqttMess);


### PR DESCRIPTION
timestamp, rssi, power and pulse are all integer types. This PR removes the use of strings for them in JSON status message.