### PR TITLE
Add support for auto discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,32 @@
 # EspSparsnasGateway
 
-This is a Mqtt Gateway for Ikeas energy monitor Sparsnas. The monitor
+This is a MQTT Gateway for Ikeas energy monitor Sparsnas. The monitor
 sends encoded data by radio to a control panel. This device collects the data
-and sends it to Mqtt-enabled receivers in Json-format.
+and sends it to MQTT-enabled receivers in json-format.
 
 The data is also printed to the seriaĺ port. If the reception is bad, the received data can be bad.
-This gives a CRC-error, the data is in this case not sent via Mqtt but printed via the serial port.
+This gives a CRC-error, the data is in this case not sent via MQTT but printed via the serial port.
 
-The data sent via Mqtt is in Json format and looks like this:
+The data sent via MQTT is in json format and looks like this:
 
+```json
+{
+    "error": "",
+    "seq": 28767,
+    "timestamp": 1592040611,
+    "watt": 1920,
+    "total": 15016,
+    "battery": 100,
+    "rssi": -123,
+    "power": 80,
+    "pulse": 150160049
+}
 ```
- {"seq":63009,"watt":5120,"total":5985,"battery":100,"rssi":"-136","power":"720","pulse":"5985167"}
 
-```
-
-The device uses two Mqtt topics to publish, EspSparsnasGateway/values and EspSparsnasGateway/debug.
+The device uses two Mqtt topics to publish, `EspSparsnasGateway/<sensor_id>/state` and `EspSparsnasGateway/debugV2`.
 
 ## Using
-Load the project files in Atom/VS Code with PlatformIO. Then copy the file "include/settings.example" to "include/settings.h". Adjust the values in settings.h to fit your environment and save it. Upload to your hardware and enjoy :)
+Load the project files in Atom/VS Code with PlatformIO. Then copy the file `include/settings.example.h` to `include/settings.h`. Adjust the values in `settings.h` to fit your environment and save it. Upload to your hardware and enjoy :)
 
 ## Hardware
 The hardware used is a Esp8266-based wifi-enabled Mcu. You can use different devices like a Wemos Mini or a Nodemcu, but take care of the Gpio labels that can differ. The receiver is a RFM69B radio transciever. I use a 868MHz device, but a 900MHz should work as well. To this a simple antenna is connected, I use a straight wire, 86 millimeters long connected to the RFM's Ant-connection. The wire shall be vertical, standing up. You can also add a similar wire to the gnd-connection next to the antenna connection, pointing down, opposite to the first wire.
@@ -26,14 +35,14 @@ The connection for the RFM69 is hardcoded. This is standard Spi connections set 
 
 The schematic shows a Nodemcu, but you can use another ESP8266-based device if you want (except the Esp-01). Use these pin mappings:
 
-```
-NodeMcu - Esp12
-D1	- Gpio5
-D5	- Gpio14
-D6	- Gpio12
-D7	- Gpio13
-D8	- Gpio15
-```
+| NodeMcu | Esp12 |
+|----|--------|
+| D1 | Gpio5  |
+| D5 | Gpio14 |
+| D6 | Gpio12 |
+| D7 | Gpio13 |
+| D8 | Gpio15 |
+
 
 ![Wiring diagram](https://github.com/bphermansson/EspSparsnasGateway/raw/master/EspSparsnasGateway_schem_Nodemcu.png)
 
@@ -72,45 +81,45 @@ You can use the device with a simple USB power supply and get data via Mqtt. The
 ### Enable debug
 Further more information is given by the device if debug is activated:
 
-```
+```c++
 #define DEBUG 1
 ```
 
 ### Change the channel filter width
 With some RFM's a software adjustment can be tested if the code doesn't work. Line 213 in RFM69functions.cpp looks like this:
 
-```
+```c++
 /* 0x19 */ {REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_4}, // p26 in datasheet, filters out noise
 ```
 
 You can try to change this to:
 
-```
+```c++
 /* 0x19 */ {REG_RXBW, RF_RXBW_DCCFREQ_010 | RF_RXBW_MANT_16 | RF_RXBW_EXP_3}, // p26 in datasheet, filters out noise
 ```
 
 This makes the channel filter wider, 62.5khz instead of 31.3khz.
 
 ## Home Assistant integration
-The Mqtt data can be used anywhere, here's an example for the Home Automation software Home Assistant.
+Sensors for power (Watt) and energy (kWh) will be created automatically if Home Assistant is configured to support [discovery](https://www.home-assistant.io/docs/mqtt/discovery/#discovery).
+The MQTT data can however be used anywhere, here's an example for the Home Automation software Home Assistant.
 In Home Assistant the sensors can look like this:
 
-```
+```yaml
 - platform: mqtt
-  state_topic: "EspSparsnasGateway/valuesV2"
+  state_topic: "EspSparsnasGateway/+/state"
   name: "House power usage"
   unit_of_measurement: "W"
   value_template: '{{ float(value_json.watt) | round(0)  }}'
 
 - platform: mqtt
-  state_topic: "EspSparsnasGateway/valuesV2"
+  state_topic: "EspSparsnasGateway/+/state"
   name: "House energy usage"
   unit_of_measurement: "kWh"
   value_template: '{{ float(value_json.total) | round(0)  }}'
-    
 
 - platform: mqtt
-  state_topic: "EspSparsnasGateway/valuesV2"
+  state_topic: "EspSparsnasGateway/+/state"
   name: "House energy meter batt"
   unit_of_measurement: "%"
   value_template: '{{ float(value_json.battery) }}'
@@ -118,7 +127,7 @@ In Home Assistant the sensors can look like this:
 
 We then get these sensors:
 
-```
+```yaml
 -sensor.house_energy_meter_batt
 -sensor.house_energy_usage
 -sensor.house_power_usage

--- a/include/settings.example.h
+++ b/include/settings.example.h
@@ -20,6 +20,7 @@
   #define MQTT_PASSWORD "YOUR_MQTT_PASSWORD"
   #define MQTT_SERVER "YOUR_MQTT_SERVER_IP"
   #define MQTT_PORT 1883
+  #define DISCOVERY_PREFIX "homeassistant"
 
   // WiFi settings
   #define WIFISSID "YOUR_WIFI_SSID"

--- a/src/EspSparsnasGateway.cpp
+++ b/src/EspSparsnasGateway.cpp
@@ -66,7 +66,7 @@ void setup() {
 
   digitalWrite(LED_RED, LOW);
   digitalWrite(LED_GREEN, LOW);
-  digitalWrite(LED_BLUE, LOW);
+  digitalWrite(LED_BLUE, HIGH);
   delay(500);
 
   blinkerGreen.attach(0.5, changeStateLED_GREEN);

--- a/src/RFM69functions.cpp
+++ b/src/RFM69functions.cpp
@@ -20,7 +20,8 @@ static volatile uint8_t DATALEN;
 
 static const char* mqtt_status_topic = "EspSparsnasGateway/valuesV2";
 static const char* mqtt_debug_topic = "EspSparsnasGateway/debugV2";
-static String mqttMess;
+const String sensor_id = String(SENSOR_ID);
+const String state_topic = APPNAME "/" + sensor_id + "/state"; 
 
 extern PubSubClient mClient;
 
@@ -43,6 +44,8 @@ extern timeval tv;
 extern timespec tp;
 extern time_t now;
 extern "C" int clock_gettime(clockid_t unused, struct timespec *tp);
+
+extern void publish_mqtt(String, String);
 
 int16_t readRSSI();
 
@@ -451,10 +454,11 @@ void  ICACHE_RAM_ATTR interruptHandler() {
       status["power"] = power;
       status["pulse"] = pulse;
 
-      mqttMess = "";
+      String mqttMess;
       serializeJson(status, mqttMess);
 
       if (status["error"] == "") {
+        publish_mqtt(state_topic, mqttMess);
         mClient.publish((char*) String(mqtt_status_topic).c_str(), (char*) mqttMess.c_str());
       }
       analogWrite(LED_BLUE, 0);

--- a/src/reconn.cpp
+++ b/src/reconn.cpp
@@ -6,7 +6,7 @@
 extern PubSubClient mClient;
 const String sensor_id = String(SENSOR_ID);
 const String availability_topic = APPNAME "/" + sensor_id + "/availability";
-const String state_topic = APPNAME "/" + sensor_id + "/state"; 
+const String state_topic = APPNAME "/" + sensor_id + "/state";
 const String discovery_topic = "home/sensor/" APPNAME "_" + sensor_id;
 
 bool send_discovery_message(const char* measurement, const char* value_template) {
@@ -26,7 +26,7 @@ bool send_discovery_message(const char* measurement, const char* value_template)
   config["unique_id"] = (APPNAME "_") + sensor_id + "_" + measurement;
   config["state_topic"] = state_topic;
   config["json_attributes_topic"] = state_topic;
-  config["availability_topic"] = availability_topic.c_str(); 
+  config["availability_topic"] = availability_topic.c_str();
   config["value_template"] = value_template;
 
   String ret;
@@ -70,7 +70,7 @@ void reconnect() {
     #ifdef DEBUG
       Serial.print("Attempting MQTT connection...");
     #endif
-    if (mClient.connect(APPNAME, MQTT_USERNAME, MQTT_PASSWORD)) {
+    if (mClient.connect(APPNAME, MQTT_USERNAME, MQTT_PASSWORD, availability_topic.c_str(), 0, true, "offline")) {
       #ifdef DEBUG
         String buf = "Connected to Mqtt broker as " + String(APPNAME);
         Serial.println(buf);
@@ -79,7 +79,9 @@ void reconnect() {
       send_discovery_message("W", "{{ value_json.watt | round(1) }}");
       send_discovery_message("kWh", "{{ value_json.total | round(1) }}");
 
+      mClient.publish(availability_topic.c_str(), "online", true);
 
+      return;
     } else {
       Serial.print("Mqtt connection failed,");
       Serial.println(" try again in 5 seconds");

--- a/src/reconn.cpp
+++ b/src/reconn.cpp
@@ -1,8 +1,65 @@
 #include <Arduino.h>
 #include <PubSubClient.h>
-#include <settings.h>
+#include <ArduinoJson.h>
+#include "settings.h"
 
 extern PubSubClient mClient;
+const String sensor_id = String(SENSOR_ID);
+const String availability_topic = APPNAME "/" + sensor_id + "/availability";
+const String state_topic = APPNAME "/" + sensor_id + "/state"; 
+const String discovery_topic = "home/sensor/" APPNAME "_" + sensor_id;
+
+bool send_discovery_message(const char* measurement, const char* value_template) {
+  DynamicJsonDocument device(JSON_OBJECT_SIZE(12));
+  DynamicJsonDocument config(JSON_OBJECT_SIZE(30));
+
+  device["sw_version"] = __TIME__ " " __DATE__;
+  device["name"] = String(APPNAME " ") + sensor_id;
+  device["identifiers"] = String(APPNAME "") + sensor_id;
+  device["model"] = APPNAME;
+  device["manufacturer"] = "IKEA";
+
+  config["device"] = device;
+  config["device_class"] = "power";
+  config["unit_of_measurement"] = measurement;
+  config["name"] = String("ESP Sparsnäs ") + measurement;
+  config["unique_id"] = (APPNAME "_") + sensor_id + "_" + measurement;
+  config["state_topic"] = state_topic;
+  config["json_attributes_topic"] = state_topic;
+  config["availability_topic"] = availability_topic.c_str(); 
+  config["value_template"] = value_template;
+
+  String ret;
+  serializeJson(config, ret);
+  //Serial.print("Discovery message ");
+  //Serial.print(strlen(ret.c_str()));
+  //Serial.println(ret.c_str());
+
+  mClient.beginPublish(
+    (String(discovery_topic) + "/" + measurement + "/config").c_str(),
+    ret.length(),
+    true
+  );
+  for (uint i=0; i<ret.length(); i+=64) {
+    mClient.print(ret.substring(i, i+64));
+  }
+  mClient.endPublish();
+  return true;
+}
+
+void publish_mqtt(String topic, String message) {
+  Serial.print("Will publish:");
+  Serial.println(message);
+  mClient.beginPublish(
+    (topic).c_str(),
+    message.length(),
+    false
+  );
+  for (uint i=0; i<message.length(); i+=64) {
+    mClient.print(message.substring(i, i+64));
+  }
+  mClient.endPublish();
+}
 
 void reconnect() {
   #ifdef DEBUG
@@ -18,6 +75,10 @@ void reconnect() {
         String buf = "Connected to Mqtt broker as " + String(APPNAME);
         Serial.println(buf);
       #endif
+
+      send_discovery_message("W", "{{ value_json.watt | round(1) }}");
+      send_discovery_message("kWh", "{{ value_json.total | round(1) }}");
+
 
     } else {
       Serial.print("Mqtt connection failed,");

--- a/src/reconn.cpp
+++ b/src/reconn.cpp
@@ -7,7 +7,7 @@ extern PubSubClient mClient;
 const String sensor_id = String(SENSOR_ID);
 const String availability_topic = APPNAME "/" + sensor_id + "/availability";
 const String state_topic = APPNAME "/" + sensor_id + "/state";
-const String discovery_topic = "home/sensor/" APPNAME "_" + sensor_id;
+const String discovery_topic = DISCOVERY_PREFIX "/sensor/" APPNAME "_" + sensor_id;
 
 bool send_discovery_message(const char* measurement, const char* value_template) {
   DynamicJsonDocument device(JSON_OBJECT_SIZE(12));
@@ -31,9 +31,6 @@ bool send_discovery_message(const char* measurement, const char* value_template)
 
   String ret;
   serializeJson(config, ret);
-  //Serial.print("Discovery message ");
-  //Serial.print(strlen(ret.c_str()));
-  //Serial.println(ret.c_str());
 
   mClient.beginPublish(
     (String(discovery_topic) + "/" + measurement + "/config").c_str(),
@@ -62,9 +59,6 @@ void publish_mqtt(String topic, String message) {
 }
 
 void reconnect() {
-  #ifdef DEBUG
-    Serial.print("Reconnect");
-  #endif
   // Loop until we're reconnected
   while (!mClient.connected()) {
     #ifdef DEBUG
@@ -78,12 +72,9 @@ void reconnect() {
 
       send_discovery_message("W", "{{ value_json.watt | round(1) }}");
       send_discovery_message("kWh", "{{ value_json.total | round(1) }}");
-
       mClient.publish(availability_topic.c_str(), "online", true);
-
-      return;
     } else {
-      Serial.print("Mqtt connection failed,");
+      Serial.print("MQTT connection failed,");
       Serial.println(" try again in 5 seconds");
       // Wait 5 seconds before retrying
       delay(5000);


### PR DESCRIPTION
This adds support for https://www.home-assistant.io/docs/mqtt/discovery/.

I.e. if MQTT is configured to use discovery the Sparsnas sensors will appear automatically.


Closes #54.
