### PR TITLE
Add device_class and state_class parameters to send_discovery_message and send correct values

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ sensor:
     unit_of_measurement: "kWh"
     value_template: "{{ float(value_json.total) | round(0)  }}"
     icon: mdi:flash-circle
-    state_class: measurement
+    state_class: total_increasing
     device_class: energy
 
   - state_topic: "EspSparsnasGateway/valuesV2"

--- a/src/reconn.cpp
+++ b/src/reconn.cpp
@@ -9,7 +9,7 @@ const String availability_topic = APPNAME "/" + sensor_id + "/availability";
 const String state_topic = APPNAME "/" + sensor_id + "/state";
 const String discovery_topic = DISCOVERY_PREFIX "/sensor/" APPNAME "_" + sensor_id;
 
-bool send_discovery_message(const char* measurement, const char* value_template) {
+bool send_discovery_message(const char* measurement, const char* device_class, const char* state_class, const char* value_template) {
   DynamicJsonDocument device(JSON_OBJECT_SIZE(12));
   DynamicJsonDocument config(JSON_OBJECT_SIZE(30));
 
@@ -20,7 +20,8 @@ bool send_discovery_message(const char* measurement, const char* value_template)
   device["manufacturer"] = "IKEA";
 
   config["device"] = device;
-  config["device_class"] = "power";
+  config["device_class"] = device_class;
+  config["state_class"] = state_class;
   config["unit_of_measurement"] = measurement;
   config["name"] = String("ESP Sparsnäs ") + measurement;
   config["unique_id"] = (APPNAME "_") + sensor_id + "_" + measurement;
@@ -70,8 +71,8 @@ void reconnect() {
         Serial.println(buf);
       #endif
 
-      send_discovery_message("W", "{{ value_json.watt | round(1) }}");
-      send_discovery_message("kWh", "{{ value_json.total | round(1) }}");
+      send_discovery_message("W", "power", "measurement", "{{ value_json.watt | round(1) }}");
+      send_discovery_message("kWh", "energy", "total_increasing", "{{ value_json.total | round(1) }}");
       mClient.publish(availability_topic.c_str(), "online", true);
     } else {
       Serial.print("MQTT connection to " MQTT_SERVER " failed,");


### PR DESCRIPTION
This enables using the discovered sensors in the home assistant energy dashboard.
Also fixed the readme with the same changes so should solve #64